### PR TITLE
Ensure unitless width/height in SVG still works

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,12 +14,11 @@ function renderPrettyDate(uglyDate) {
 
 function parseDimension(dimensionValue, dimensionName, directoryName, imageName) {
     const dimensionAsString = dimensionValue;
+    const dimensionAsInt = parseInt(dimensionAsString)
 
-    if (!dimensionAsString.endsWith("px")) {
+    if (!dimensionAsString.endsWith("px") && ("" + dimensionAsInt) !== dimensionAsString) {
         throw new Error(dimensionName + " must end with px, but it rather is: " + dimensionAsString);
     }
-
-    const dimensionAsInt = parseInt(dimensionAsString)
 
     if (dimensionAsInt == NaN) {
         throw new Error(dimensionName + " must be integer, but it rather is: " + dimensionAsString);


### PR DESCRIPTION
The `width` and `height` attributes in `svg` tag can be unitless (e.g. `width="100"` instead of `width="100px"`). This is a completely valid SVG file but this tool fails because it expects the `px` suffix.

This PR ensures the suffix remains optional while at the same time guarding against unparseable units (like `100%` or `10em`)

Thank you for this tool BTW, I've been using it for years now ❤️ 